### PR TITLE
refactor: apply a common function to get a aws config in aws lambda and apply synchronized use statements and an explicit client

### DIFF
--- a/core/wave-autoscale/src/scaling_component/aws_lambda_function.rs
+++ b/core/wave-autoscale/src/scaling_component/aws_lambda_function.rs
@@ -2,7 +2,11 @@ use super::ScalingComponent;
 use crate::util::aws::get_aws_config;
 use anyhow::{Ok, Result};
 use async_trait::async_trait;
-use aws_sdk_lambda::{error::ProvideErrorMetadata, Client};
+
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+
+use aws_sdk_lambda::Client as LambdaClient;
+
 use data_layer::ScalingComponentDefinition;
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -67,7 +71,7 @@ impl ScalingComponent for LambdaFunctionScalingComponent {
             }
             let shared_config = config.unwrap();
 
-            let client = Client::new(&shared_config);
+            let client = LambdaClient::new(&shared_config);
 
             // Set and put reserved concurrency if provided.
             if let Some(reserved_concurrency) = reserved_concurrency {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] DevOps process (non-breaking change which improves efficiency and reliability for CI/CD)
- [ ] Documentation only

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With a common function to retrieve the aws_config, it is necessary to apply it in the AWS Lambda scaling component.

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
#122, and #83 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested with exist code in core/wave-autoscale/src/scaling_component/aws_lambda_function.rs

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
--->
