### PR TITLE
fix: vector data parsing change to 'gauge'

### DIFF
--- a/core/api-server/src/controller/metrics_receiver_controller.rs
+++ b/core/api-server/src/controller/metrics_receiver_controller.rs
@@ -68,9 +68,7 @@ async fn post_metrics_receiver(
             let metric = metric.unwrap();
             let metric_name = metric.get("name");
             let metric_tags = metric.get("tags");
-            let metric_value = metric
-                .get("counter")
-                .and_then(|counter| counter.get("value"));
+            let metric_value = metric.get("gauge").and_then(|gauge| gauge.get("value"));
 
             json_value.push(json!(
             {
@@ -146,7 +144,7 @@ mod tests {
                             "tags": {
                                 "tag1": "value1"
                             },
-                            "counter": {
+                            "gauge": {
                                 "value": 1
                             }
                         }
@@ -205,7 +203,7 @@ mod tests {
                             "tags": {
                                 "tag1": "value1"
                             },
-                            "counter": {
+                            "gauge": {
                                 "value": 1
                             }
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] DevOps process (non-breaking change which improves efficiency and reliability for CI/CD)
- [ ] Documentation only

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
vector data parsing change to 'gauge'

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixed #150 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- moon run tested - check metric data

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
--->
