### PR TITLE
fix: vector metric get value to gauge and counter & add timestamp

### DIFF
--- a/core/wave-autoscale/tests/yaml/plan_ec2_vector_prometheus_center_sample.yaml
+++ b/core/wave-autoscale/tests/yaml/plan_ec2_vector_prometheus_center_sample.yaml
@@ -1,0 +1,42 @@
+---
+kind: Metric
+id: prometheus_scrape_1
+collector: vector
+metric_kind: prometheus_scrape
+metadata:
+  endpoints:
+    - http://prometheus-simulation.waveautoscale.io:9090/federate
+  query:
+    "match[]":
+      - "nginx3_connections_waiting"
+  scrape_interval_secs: 10
+---
+kind: ScalingComponent
+id: ec2_autoscaling_server
+component_kind: aws-ec2-autoscaling
+metadata:
+  region: ap-northeast-3
+  asg_name: wave-ec2-as-nginx
+---
+kind: ScalingPlan
+id: scaling_plan_aws_asg_autoscaling
+metadata:
+  title: "Scaling Plan for AWS EC2 Autoscaling"
+  cool_down: 300 # seconds
+  interval: 10000 # milliseconds
+plans:
+  - id: scale-out-plan-1
+    description: "Scale out if nginx connections_waiting is greater than 1800."
+    # JavaScript expression that returns a boolean value.
+    expression: >
+      get({
+        metric_id: 'prometheus_scrape_1',
+        name: 'nginx3_connections_waiting',
+        stats: 'max',
+        period_sec: 15
+      }) >= 1800
+    # Higher priority values will be checked first.
+    priority: 1
+    scaling_components:
+      - component_id: ec2_autoscaling_server
+        desired: 2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] DevOps process (non-breaking change which improves efficiency and reliability for CI/CD)
- [ ] Documentation only

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- vector metric get value to gauge and counter
- metric json: add timestamp data (vector & telegraf)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #152 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- moon run tested - check metric data

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
--->
