### PR TITLE
feat: Scaling component metadata change to optional

### DIFF
--- a/core/data-layer/src/types/scaling_component_definition.rs
+++ b/core/data-layer/src/types/scaling_component_definition.rs
@@ -8,6 +8,9 @@ use ts_rs::TS;
 fn default_kind() -> ObjectKind {
     ObjectKind::ScalingComponent
 }
+fn default_metadata() -> HashMap<String, Value> {
+    HashMap::new()
+}
 
 #[derive(TS)]
 #[ts(
@@ -25,5 +28,6 @@ pub struct ScalingComponentDefinition {
     pub id: String,
     pub component_kind: String,
     #[ts(type = "object")]
+    #[serde(default = "default_metadata")]
     pub metadata: HashMap<String, Value>,
 }

--- a/examples/scaling-components/kubernetes/istio_delay.yaml
+++ b/examples/scaling-components/kubernetes/istio_delay.yaml
@@ -32,7 +32,6 @@ metadata:
 kind: ScalingComponent
 id: k8s_patch
 component_kind: kubernetes-patch
-metadata:
 ---
 kind: ScalingPlan
 id: scaling_plan_k8s_patch_scaling

--- a/examples/scaling-components/kubernetes/istio_retry.yaml
+++ b/examples/scaling-components/kubernetes/istio_retry.yaml
@@ -32,7 +32,6 @@ metadata:
 kind: ScalingComponent
 id: k8s_patch
 component_kind: kubernetes-patch
-metadata:
 ---
 kind: ScalingPlan
 id: scaling_plan_k8s_patch_scaling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] DevOps process (non-breaking change which improves efficiency and reliability for CI/CD)
- [X] Documentation only

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Scaling component - metadata change to optional
ex) kubernetes-patch doesn't need metadata

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #193 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* moon run tested - check the scaling component works

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
--->
